### PR TITLE
Add Service Provider configuration file

### DIFF
--- a/src/main/resources/META-INF/services/org.apache.kafka.common.config.provider.ConfigProvider
+++ b/src/main/resources/META-INF/services/org.apache.kafka.common.config.provider.ConfigProvider
@@ -1,0 +1,4 @@
+# Copyright Strimzi authors.
+# License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+
+io.strimzi.kafka.EnvVarConfigProvider

--- a/src/test/java/io/strimzi/kafka/EnvVarConfigProviderTest.java
+++ b/src/test/java/io/strimzi/kafka/EnvVarConfigProviderTest.java
@@ -14,10 +14,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.ServiceLoader;
 
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EnvVarConfigProviderTest {
     private static ConfigProvider configProvider;
@@ -78,5 +80,21 @@ public class EnvVarConfigProviderTest {
         Map<String, String> data = config.data();
 
         assertThat(data.size(), is(0));
+    }
+
+    @Test
+    public void testServiceLoaderDiscovery() {
+        ServiceLoader<ConfigProvider> serviceLoader = ServiceLoader.load(ConfigProvider.class);
+
+        boolean discovered = false;
+
+        for (ConfigProvider service : serviceLoader)    {
+            System.out.println(service.getClass());
+            if (service instanceof EnvVarConfigProvider) {
+                discovered = true;
+            }
+        }
+
+        assertTrue(discovered);
     }
 }


### PR DESCRIPTION
When the configuration provider is loaded as a plugin in Kafka Connect, it is loaded as a [Service Provider](https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Service_Provider). To be able to do this, we need to add the configuration file which lists the service implementations.