### PR TITLE
Update dependencies before the next release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <maven.gpg.version>1.6</maven.gpg.version>
         <sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
 
-        <kafka.version>3.0.0</kafka.version>
+        <kafka.version>3.1.0</kafka.version>
 
         <junit5.version>5.7.2</junit5.version>
         <hamcrest.version>2.2</hamcrest.version>


### PR DESCRIPTION
As discussed on the last Strimzi community call, we should proceed with the 1.0.0 release of the EnvVar configuration provider. This PR bumps the Kafka dependency before we do the release, to release with latest Kafka.