### PR TITLE
Bump main branch to 1.1.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.strimzi</groupId>
     <artifactId>kafka-env-var-config-provider</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <licenses>
 		<license>


### PR DESCRIPTION
Since the 1.0.0 release is out now, this PR bumps the version in the main branch to 1.1.0-SNAPSHOT.