### PR TITLE
Add Java 17 and remove Java 8

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -19,14 +19,14 @@ jobs:
     # Strategy for the job
     strategy:
       matrix:
-        'java-8':
-          image: 'Ubuntu-18.04'
-          jdk_version: '1.8'
-          jdk_path: '/usr/lib/jvm/java-8-openjdk-amd64'
         'java-11':
           image: 'Ubuntu-18.04'
           jdk_version: '11'
           jdk_path: '/usr/lib/jvm/java-11-openjdk-amd64'
+        'java-17':
+          image: 'Ubuntu-18.04'
+          jdk_version: '17'
+          jdk_path: '/usr/lib/jvm/java-17-openjdk-amd64'
     # Set timeout for jobs
     timeoutInMinutes: 60
     # Base system

--- a/.azure/scripts/build.sh
+++ b/.azure/scripts/build.sh
@@ -6,14 +6,16 @@ echo "Source branch: ${BRANCH}"
 
 # The first segment of the version number is '1' for releases < 9; then '9', '10', '11', ...
 JAVA_MAJOR_VERSION=$(java -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
-if [ ${JAVA_MAJOR_VERSION} -eq 1 ] ; then
+if [ "${JAVA_MAJOR_VERSION}" -eq "11" ] ; then
   # some parts of the workflow should be done only one on the main build which is currently Java 11
   export MAIN_BUILD="TRUE"
   echo "Running main build"
 fi
 
 # Build with Maven
+# shellcheck disable=SC2086
 mvn $MVN_ARGS install
+# shellcheck disable=SC2086
 mvn $MVN_ARGS spotbugs:check
 
 # Push to Nexus

--- a/.azure/templates/setup_java.yaml
+++ b/.azure/templates/setup_java.yaml
@@ -1,5 +1,5 @@
-# Step to setup JAVA on the agent
-# We use openjdk-X, where X is Java version (8 or 11). Images are based on Java 8
+# Step to set up JAVA on the agent
+# We use openjdk-X, where X is Java version (e.g. 11 for OpenJDK 11).
 parameters:
   - name: JDK_PATH
     default: '/usr/lib/jvm/java-8-openjdk-amd64'
@@ -12,26 +12,26 @@ steps:
   displayName: 'Update package list'
 
 - bash: |
-    sudo apt-get install openjdk-8-jdk
-  displayName: 'Install openjdk8'
-  condition: eq(variables['JDK_VERSION'], '1.8')
-
-- bash: |
     sudo apt-get install openjdk-11-jdk
   displayName: 'Install openjdk11'
   condition: eq(variables['JDK_VERSION'], '11')
-
-- bash: |
-    echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]1.8"
-    echo "##vso[task.setvariable variable=JAVA_VERSION]1.8.0"
-  displayName: 'Setup JAVA_VERSION=1.8'
-  condition: eq(variables['JDK_VERSION'], '1.8')
 
 - bash: |
     echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]11"
     echo "##vso[task.setvariable variable=JAVA_VERSION]11"
   displayName: 'Setup JAVA_VERSION=11'
   condition: eq(variables['JDK_VERSION'], '11')
+
+- bash: |
+    sudo apt-get install openjdk-17-jdk
+  displayName: 'Install openjdk17'
+  condition: eq(variables['JDK_VERSION'], '17')
+
+- bash: |
+    echo "##vso[task.setvariable variable=JAVA_VERSION_BUILD]17"
+    echo "##vso[task.setvariable variable=JAVA_VERSION]17"
+  displayName: 'Setup JAVA_VERSION=17'
+  condition: eq(variables['JDK_VERSION'], '17')
 
 - bash: |
     echo "##vso[task.setvariable variable=JAVA_HOME]$(JDK_PATH)"

--- a/.azure/templates/setup_java.yaml
+++ b/.azure/templates/setup_java.yaml
@@ -2,9 +2,9 @@
 # We use openjdk-X, where X is Java version (e.g. 11 for OpenJDK 11).
 parameters:
   - name: JDK_PATH
-    default: '/usr/lib/jvm/java-8-openjdk-amd64'
+    default: '/usr/lib/jvm/java-11-openjdk-amd64'
   - name: JDK_VERSION
-    default: '1.8'
+    default: '11'
 steps:
 
 - bash: |

--- a/pom.xml
+++ b/pom.xml
@@ -69,21 +69,23 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
-        <maven.checkstyle.version>3.1.2</maven.checkstyle.version>
-        <spotbugs.version>4.0.3</spotbugs.version>
-        <maven.surefire.version>3.0.0-M5</maven.surefire.version>
-        <maven.failsafe.version>3.0.0-M5</maven.failsafe.version>
-        <maven.javadoc.version>3.1.0</maven.javadoc.version>
-        <maven.source.version>3.0.1</maven.source.version>
-        <maven.jar.version>3.1.0</maven.jar.version>
-        <maven.assembly.version>3.1.0</maven.assembly.version>
-        <maven.gpg.version>1.6</maven.gpg.version>
-        <sonatype.nexus.staging>1.6.3</sonatype.nexus.staging>
+        <maven.checkstyle.version>3.2.0</maven.checkstyle.version>
+        <maven.spotbugs.version>4.7.3.0</maven.spotbugs.version>
+        <spotbugs.version>4.7.3</spotbugs.version>
+        <maven.surefire.version>3.0.0-M7</maven.surefire.version>
+        <maven.failsafe.version>3.0.0-M7</maven.failsafe.version>
+        <maven.javadoc.version>3.4.1</maven.javadoc.version>
+        <maven.source.version>3.2.1</maven.source.version>
+        <maven.jar.version>3.3.0</maven.jar.version>
+        <maven.assembly.version>3.4.2</maven.assembly.version>
+        <maven.gpg.version>3.0.1</maven.gpg.version>
+        <sonatype.nexus.staging>1.6.7</sonatype.nexus.staging>
 
-        <kafka.version>3.1.0</kafka.version>
+        <kafka.version>3.3.1</kafka.version>
+        <slf4j.version>1.7.36</slf4j.version>
 
         <junit5.version>5.7.2</junit5.version>
         <hamcrest.version>2.2</hamcrest.version>
@@ -110,7 +112,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -139,13 +141,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${maven.checkstyle.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>8.42</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <id>validate</id>
@@ -186,13 +181,15 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.0.0</version><dependencies>
-                <!-- overwrite dependency on spotbugs if you want to specify the version of˓→spotbugs -->
-                <dependency>
-                    <groupId>com.github.spotbugs</groupId>
-                    <artifactId>spotbugs</artifactId>
-                    <version>${spotbugs.version}</version>
-                </dependency></dependencies>
+                <version>${maven.spotbugs.version}</version>
+                <dependencies>
+                    <!-- overwrite dependency on spotbugs if you want to specify the version of˓→spotbugs -->
+                    <dependency>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs</artifactId>
+                        <version>${spotbugs.version}</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <effort>Max</effort>
                     <!-- Reports all bugs (other values are medium and max) -->

--- a/src/main/java/io/strimzi/kafka/EnvVarConfigProvider.java
+++ b/src/main/java/io/strimzi/kafka/EnvVarConfigProvider.java
@@ -51,7 +51,7 @@ public class EnvVarConfigProvider implements ConfigProvider {
 
     @Override
     public ConfigData get(String path, Set<String> keys) {
-        Map<String, String> vars = new HashMap(envVars);
+        Map<String, String> vars = new HashMap<>(envVars);
         vars.keySet().retainAll(keys);
         return new ConfigData(vars);
     }


### PR DESCRIPTION
It is time to move on -> this PR drops the Java 8 support for this plugin and moves it to Java 11+ only. As a part of that, it:
* Removes the Java 8 pipeline form the CI
* Add a new Java 17 pipeline to the CI
* Updates the dependencies and various Maven plugins to make it compatible with Java 17
* Fixes one minor warning in the code